### PR TITLE
WIP: strip 'root:' prefix from path

### DIFF
--- a/pkg/logicalcluster/logicalcluster.go
+++ b/pkg/logicalcluster/logicalcluster.go
@@ -56,7 +56,7 @@ func (l LogicalCluster) Empty() bool {
 
 // Path returns a path segment for the logical cluster to access its API.
 func (cn LogicalCluster) Path() string {
-	return path.Join("/clusters", cn.value)
+	return path.Join("/clusters", strings.TrimPrefix(cn.value, "root:"))
 }
 
 // String returns the string representation of the logical cluster name.


### PR DESCRIPTION
We could do that, to get the old behaviour. Not sure we should. Opinions?