### PR TITLE
OPINIONS: logicalcluster: drop root in pretty strings and accept :org:ws as short-hand

### DIFF
--- a/pkg/logicalcluster/logicalcluster.go
+++ b/pkg/logicalcluster/logicalcluster.go
@@ -44,6 +44,9 @@ var (
 
 // New returns a logical cluster from a string.
 func New(value string) LogicalCluster {
+	if strings.HasPrefix(value, seperator) {
+		return LogicalCluster{"root" + value}
+	}
 	return LogicalCluster{value}
 }
 
@@ -59,6 +62,15 @@ func (cn LogicalCluster) Path() string {
 
 // String returns the string representation of the logical cluster name.
 func (cn LogicalCluster) String() string {
+	return cn.value
+}
+
+// PrettyString returns the string representation of the logical cluster name,
+// with a possible "root" prefix removed.
+func (cn LogicalCluster) PrettyString() string {
+	if strings.HasPrefix(cn.value, "root"+seperator) {
+		return strings.TrimPrefix(cn.value, "root")
+	}
 	return cn.value
 }
 

--- a/pkg/logicalcluster/logicalcluster_test.go
+++ b/pkg/logicalcluster/logicalcluster_test.go
@@ -18,6 +18,7 @@ package logicalcluster
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,4 +68,45 @@ func TestJSON(t *testing.T) {
 	err = json.Unmarshal(bs, &jwt2)
 	require.NoError(t, err)
 	require.Equal(t, jwt, jwt2)
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		value string
+		want  LogicalCluster
+	}{
+		{"", LogicalCluster{}},
+		{"root", LogicalCluster{value: "root"}},
+		{"root:foo:bar", LogicalCluster{value: "root:foo:bar"}},
+		{"system:admin", LogicalCluster{value: "system:admin"}},
+
+		{":foo:bar", LogicalCluster{value: "root:foo:bar"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := New(tt.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrettyString(t *testing.T) {
+	tests := []struct {
+		cluster string
+		want    string
+	}{
+		{"", ""},
+		{"root", "root"},
+		{"root:foo:bar", ":foo:bar"},
+		{"system:admin", "system:admin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cluster, func(t *testing.T) {
+			lc := LogicalCluster{value: tt.cluster}
+			if got := lc.PrettyString(); got != tt.want {
+				t.Errorf("PrettyString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
How do you think about this?

It would allow to write `/clusters/:org:ws`, same for the plugin `kubectl ws :org:ws`.

We could also decide to just have this on the CLI level, but only accept `/clusters/root:org:ws` on the server side. I slightly tend to that variant.