### PR TITLE
Add cluster aware round tripper

### DIFF
--- a/pkg/client/round_tripper.go
+++ b/pkg/client/round_tripper.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+)
+
+// ClusterRoundTripper is a cluster aware wrapper around http.RoundTripper
+type ClusterRoundTripper struct {
+	delegate http.RoundTripper
+}
+
+// NewClusterRoundTripper creates a new cluster aware round tripper
+func NewClusterRoundTripper(delegate http.RoundTripper) *ClusterRoundTripper {
+	return &ClusterRoundTripper{
+		delegate: delegate,
+	}
+}
+
+func (c *ClusterRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cluster, ok := ClusterFromContext(req.Context())
+	if !ok {
+		return nil, fmt.Errorf("expected cluster in context")
+	}
+	req = req.Clone(req.Context())
+	req.URL.Path = generatePath(req.URL.Path, cluster)
+	req.URL.RawPath = generatePath(req.URL.RawPath, cluster)
+
+	return c.delegate.RoundTrip(req)
+}
+
+// generatePath formats the request path to target the specified cluster
+func generatePath(originalPath string, cluster logicalcluster.LogicalCluster) string {
+	// start with /clusters/$name
+	path := cluster.Path()
+
+	// if the original path is relative, add a / separator
+	if len(originalPath) > 0 && originalPath[0] != '/' {
+		path += "/"
+	}
+
+	// finally append the original path
+	path += originalPath
+	return path
+}
+
+type key int
+
+const (
+	keyCluster key = iota
+)
+
+// WithCluster injects a cluster name into a context
+func WithCluster(ctx context.Context, cluster logicalcluster.LogicalCluster) context.Context {
+	return context.WithValue(ctx, keyCluster, cluster)
+}
+
+// ClusterFromContext extracts a cluster name from the context
+func ClusterFromContext(ctx context.Context) (logicalcluster.LogicalCluster, bool) {
+	s, ok := ctx.Value(keyCluster).(logicalcluster.LogicalCluster)
+	return s, ok
+}

--- a/pkg/client/round_tripper_test.go
+++ b/pkg/client/round_tripper_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+)
+
+func TestRoundTripper_generatePath(t *testing.T) {
+	tests := []struct {
+		originalPath string
+		cluster      logicalcluster.LogicalCluster
+		desired      string
+	}{
+		{"", logicalcluster.New("test"), "/clusters/test"},
+		{"/prefix/", logicalcluster.New("test"), "/clusters/test/prefix/"},
+		{"/several/divisions/of/prefix", logicalcluster.New("test"), "/clusters/test/several/divisions/of/prefix"},
+		{"/prefix", logicalcluster.New("test"), "/clusters/test/prefix"},
+		{"prefix", logicalcluster.New("test"), "/clusters/test/prefix"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desired, func(t *testing.T) {
+			result := generatePath(tt.originalPath, tt.cluster)
+			if result != tt.desired {
+				t.Errorf("got %v, want %v", result, tt.desired)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Required for the generated clientset wrappers:
https://github.com/kcp-dev/client-gen/pull/1