### PR TITLE
pkg/logicalcluster/indexer.go: add indexer by logical cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,13 @@ module github.com/kcp-dev/apimachinery
 go 1.17
 
 require (
+	github.com/kcp-dev/logicalcluster v1.0.0
+	github.com/stretchr/testify v1.7.1
+	k8s.io/apimachinery v0.23.5
+	k8s.io/client-go v0.23.5
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -13,11 +20,9 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kcp-dev/logicalcluster v1.0.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.7.1
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
@@ -30,8 +35,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.23.5 // indirect
-	k8s.io/apimachinery v0.23.5
-	k8s.io/client-go v0.23.5
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect

--- a/pkg/logicalcluster/indexer.go
+++ b/pkg/logicalcluster/indexer.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"fmt"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	ByWorkspaceIndex = "kcp-byWorkspace"
+)
+
+// IndexByWorkspace returns an index using the underlying logical cluster name of the given object.
+// It returns an error if the given object is not of meta/v1#Object type.
+// It is meant to be consumed as an indexer function in SharedIndexInformer#AddIndexers.
+func IndexByWorkspace(obj interface{}) ([]string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
+	}
+
+	lcluster := logicalcluster.From(metaObj)
+	return []string{lcluster.String()}, nil
+}
+
+// AddByWorkspaceIndexer registers an indexer which indexes objects by their associated logical cluster.
+// If the indexer is already registered, the function will be a no-op and return immediately without error.
+// It returns an error if adding the indexer failed.
+//
+// The indexer can be referenced using the ByWorkspaceIndex const,
+// i.e. informer.GetIndexer().ByIndex(logicalcluster.ByWorkspaceIndex, "clusterFoo")
+func AddByWorkspaceIndexer(informer cache.SharedIndexInformer) error {
+	if _, found := informer.GetIndexer().GetIndexers()[ByWorkspaceIndex]; !found {
+		err := informer.AddIndexers(cache.Indexers{
+			ByWorkspaceIndex: IndexByWorkspace,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds indexer support for informers by the object's underlying logical cluster name.

I found many occurrences of the same function in quite many places, i.e.:
- https://github.com/kcp-dev/kcp/blob/22bb87740e52d4e7a7ad7039e84eeaf49098a7fb/pkg/reconciler/scheduling/location/location_indexes.go#L27
- https://github.com/kcp-dev/kcp/blob/d097be9965e146b0616b94f57608b4cd7de96b05/pkg/reconciler/scheduling/placement/placement_indexes.go#L30
- https://github.com/kcp-dev/kcp/blob/22bb87740e52d4e7a7ad7039e84eeaf49098a7fb/pkg/reconciler/workload/apiexport/apiexport_indexes.go#L27`

Further, this prevents inconsistent indexer function usage, i.e. https://github.com/kcp-dev/kcp/blob/9cb81dbf470ef6f5f6fb3f4790fecf206470b030/pkg/authorization/apibinding_authorizer.go#L50-L52 and https://github.com/kcp-dev/kcp/blob/9cb81dbf470ef6f5f6fb3f4790fecf206470b030/pkg/authorization/apibinding_authorizer.go#L63-L65.

cc @sttts @ncdc 