### PR TITLE
Remove cluster context helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/kcp-dev/apimachinery
 go 1.17
 
 require (
-	github.com/kcp-dev/logicalcluster v1.0.0
+	github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5
 	github.com/stretchr/testify v1.7.1
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/kcp-dev/logicalcluster v1.0.0 h1:qCnoUNaqJ0Tgefkj3vXn17EC76AP44WZwnIuHLw6yGQ=
-github.com/kcp-dev/logicalcluster v1.0.0/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
+github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5 h1:ygcM+nvb7QBB/o3HZVw5sYu6KH9aXcrZ+A+IjEDAabA=
+github.com/kcp-dev/logicalcluster v1.1.1-0.20220705215104-8e46328c24a5/go.mod h1:M0CBFkJTW29XtIP5XIkDfhYQ8LU6HrnseRb4zmgBltE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/client/round_tripper.go
+++ b/pkg/client/round_tripper.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -38,7 +37,7 @@ func NewClusterRoundTripper(delegate http.RoundTripper) *ClusterRoundTripper {
 }
 
 func (c *ClusterRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	cluster, ok := ClusterFromContext(req.Context())
+	cluster, ok := logicalcluster.ClusterFromContext(req.Context())
 	if ok {
 		req = req.Clone(req.Context())
 		req.URL.Path = generatePath(req.URL.Path, cluster)
@@ -70,24 +69,4 @@ func generatePath(originalPath string, cluster logicalcluster.Name) string {
 	path += originalPath
 
 	return path
-}
-
-type key int
-
-const (
-	keyCluster key = iota
-)
-
-// WithCluster injects a cluster name into a context
-func WithCluster(ctx context.Context, cluster logicalcluster.Name) context.Context {
-	if !cluster.Empty() {
-		return context.WithValue(ctx, keyCluster, cluster)
-	}
-	return ctx
-}
-
-// ClusterFromContext extracts a cluster name from the context
-func ClusterFromContext(ctx context.Context) (logicalcluster.Name, bool) {
-	s, ok := ctx.Value(keyCluster).(logicalcluster.Name)
-	return s, ok
 }


### PR DESCRIPTION
Follow up of https://github.com/kcp-dev/logicalcluster/pull/10

TODO: bump go.mod to use latest commit after the above PR is merged.