### PR TITLE
Make GenericClusterLister implement cache.GenericLister

### DIFF
--- a/pkg/cache/listers.go
+++ b/pkg/cache/listers.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+var _ cache.GenericLister = &GenericClusterLister{}
+
 // NewGenericClusterLister creates a new instance for the GenericClusterLister.
 func NewGenericClusterLister(indexer cache.Indexer, resource schema.GroupResource) *GenericClusterLister {
 	return &GenericClusterLister{
@@ -57,6 +59,16 @@ func (s *GenericClusterLister) ByCluster(cluster logicalcluster.Name) cache.Gene
 		resource: s.resource,
 		cluster:  cluster,
 	}
+}
+
+// ByNamespace allows GenericClusterLister to implement cache.GenericLister
+func (s *GenericClusterLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	panic("Calling 'ByNamespace' is not supported before scoping lister to a workspace")
+}
+
+// Get allows GenericClusterLister to implement cache.GenericLister
+func (s *GenericClusterLister) Get(name string) (runtime.Object, error) {
+	panic("Calling 'Get' is not supported before scoping lister to a workspace")
 }
 
 type genericLister struct {


### PR DESCRIPTION
This is required for our informergen to generate upstream interface compatible informers.