### PR TITLE
NewClusterConfig and ConfigWithCluster don't make a copy of the rest config

### DIFF
--- a/pkg/client/cluster_config.go
+++ b/pkg/client/cluster_config.go
@@ -24,21 +24,23 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// NewClusterConfig wraps an existing config's roundtripper
+// SetMultiClusterRoundTripper wraps an existing config's roundtripper
 // with a custom cluster aware roundtripper.
-func NewClusterConfig(cfg *rest.Config) *rest.Config {
-	copyCfg := rest.CopyConfig(cfg)
-	copyCfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+//
+// Note: it is the caller responsibility to make a copy of the rest config
+func SetMultiClusterRoundTripper(cfg *rest.Config) *rest.Config {
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 		return NewClusterRoundTripper(rt)
 	})
 
-	return copyCfg
+	return cfg
 }
 
-// ConfigWithCluster modifies the config host path to include the
+// SetCluster modifies the config host path to include the
 // cluster endpoint.
-func ConfigWithCluster(cfg *rest.Config, clusterName logicalcluster.Name) *rest.Config {
-	r := rest.CopyConfig(cfg)
-	r.Host = r.Host + clusterName.Path()
-	return r
+//
+// Note: it is the caller responsibility to make a copy of the rest config
+func SetCluster(cfg *rest.Config, clusterName logicalcluster.Name) *rest.Config {
+	cfg.Host = cfg.Host + clusterName.Path()
+	return cfg
 }


### PR DESCRIPTION
It turns out that copying inside those functions leads to confusion.
There are parts that make an additional copy, parts that rely on the fact
that the copy is made inside, and other parts doing nothing.

Thus it would be better if callers could make a copy.
It would be explicit and would reduce the number of copies in general.


In addition to that `NewClusterConfig` has been renamed to `SetMultiClusterRoundTripper` and `ConfigWithCluster` to `SetCluster`