### PR TITLE
:bug: cache: stop implementing generic lister with panics

### DIFF
--- a/pkg/cache/listers.go
+++ b/pkg/cache/listers.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-var _ cache.GenericLister = &GenericClusterLister{}
-
 // NewGenericClusterLister creates a new instance for the GenericClusterLister.
 func NewGenericClusterLister(indexer cache.Indexer, resource schema.GroupResource) *GenericClusterLister {
 	return &GenericClusterLister{
@@ -59,16 +57,6 @@ func (s *GenericClusterLister) ByCluster(cluster logicalcluster.Name) cache.Gene
 		resource: s.resource,
 		cluster:  cluster,
 	}
-}
-
-// ByNamespace allows GenericClusterLister to implement cache.GenericLister
-func (s *GenericClusterLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
-	panic("Calling 'ByNamespace' is not supported before scoping lister to a workspace")
-}
-
-// Get allows GenericClusterLister to implement cache.GenericLister
-func (s *GenericClusterLister) Get(name string) (runtime.Object, error) {
-	panic("Calling 'Get' is not supported before scoping lister to a workspace")
 }
 
 type genericLister struct {


### PR DESCRIPTION
In practice, having this interface implemented but entirely unusable is not really going to be something we want to go forward with.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @ncdc 