### PR TITLE
:sparkles: informers: expose a scope-able interface

### DIFF
--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"github.com/kcp-dev/logicalcluster/v2"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ScopeableSharedIndexInformer is an informer that knows how to scope itself down to one cluster,
+// or act as an informer across clusters.
+type ScopeableSharedIndexInformer interface {
+	Cluster(cluster logicalcluster.Name) cache.SharedIndexInformer
+	cache.SharedIndexInformer
+}

--- a/third_party/informers/scoped_shared_informer.go
+++ b/third_party/informers/scoped_shared_informer.go
@@ -23,17 +23,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-var _ cache.SharedIndexInformer = (*sharedIndexInformer)(nil)
-
-// ScopeSharedIndexInformer wraps a shared index informer to scope all future event
-// handlers to events from a specific cluster.
-func ScopeSharedIndexInformer(informer cache.SharedIndexInformer, cluster logicalcluster.Name) cache.SharedIndexInformer {
-	return &scopedSharedIndexInformer{
-		sharedIndexInformer: informer.(*sharedIndexInformer),
-		cluster:             cluster,
-	}
-}
-
 // scopedSharedIndexInformer ensures that event handlers added to the underlying
 // informer are only called with objects matching the given logical cluster
 type scopedSharedIndexInformer struct {


### PR DESCRIPTION
We need something strongly typed, so that users can differentiate between the two and so that we don't need to do any casting on the package boundary.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Follow-up to #59 