### PR TITLE
🌱 switch to logicalcluster.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,4 @@
-// This is a generated file. Do not edit directly.
-
-module github.com/kcp-dev/apimachinery
+module github.com/kcp-dev/apimachinery/v2
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ module github.com/kcp-dev/apimachinery
 go 1.18
 
 require (
-	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
+	github.com/google/go-cmp v0.5.5
+	github.com/kcp-dev/logicalcluster/v3 v3.0.0
 	github.com/stretchr/testify v1.7.1
+	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
 	k8s.io/klog/v2 v2.60.1
@@ -14,25 +16,14 @@ require (
 )
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
-	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.19.5 // indirect
-	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
@@ -45,8 +36,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.24.3 // indirect
-	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 h1:6EMfOioekQNrpcHEK7k2ANBWogFMlf+3xTB3CC4k+2s=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v3 v3.0.0 h1:tH6M2NuA11eLMsxii9IDOGo64X8B+P3e3pC6W2oEsx8=
+github.com/kcp-dev/logicalcluster/v3 v3.0.0/go.mod h1:6rb68Tntup98cRr9+50rvSDxUbfqrC1yQ/T6RiZcSgA=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/cache/controller.go
+++ b/pkg/cache/controller.go
@@ -19,7 +19,8 @@ package cache
 import (
 	"fmt"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 )
 

--- a/pkg/cache/controller_test.go
+++ b/pkg/cache/controller_test.go
@@ -19,8 +19,9 @@ package cache
 import (
 	"testing"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/cache/informers.go
+++ b/pkg/cache/informers.go
@@ -17,13 +17,14 @@ limitations under the License.
 package cache
 
 import (
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/client-go/tools/cache"
 )
 
 // ScopeableSharedIndexInformer is an informer that knows how to scope itself down to one cluster,
 // or act as an informer across clusters.
 type ScopeableSharedIndexInformer interface {
-	Cluster(cluster logicalcluster.Name) cache.SharedIndexInformer
+	Cluster(clusterName logicalcluster.Name) cache.SharedIndexInformer
 	cache.SharedIndexInformer
 }

--- a/pkg/cache/keyfunc.go
+++ b/pkg/cache/keyfunc.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/tools/cache"
 )
@@ -75,14 +76,14 @@ func SplitMetaClusterNamespaceKey(key string) (clusterName logicalcluster.Name, 
 		if err != nil {
 			err = invalidKey
 		}
-		return logicalcluster.Name{}, namespace, name, err
+		return "", namespace, name, err
 	case 2:
 		namespace, name, err := cache.SplitMetaNamespaceKey(outerParts[1])
 		if err != nil {
 			err = invalidKey
 		}
-		return logicalcluster.New(outerParts[0]), namespace, name, err
+		return logicalcluster.Name(outerParts[0]), namespace, name, err
 	default:
-		return logicalcluster.Name{}, "", "", invalidKey
+		return "", "", "", invalidKey
 	}
 }

--- a/pkg/cache/keyfunc_test.go
+++ b/pkg/cache/keyfunc_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -156,14 +157,14 @@ func TestSplitMetaClusterNamespaceKey(t *testing.T) {
 		{
 			name:              "fully populated key",
 			key:               "clusterName|namespace/name",
-			expectedCluster:   logicalcluster.New("clusterName"),
+			expectedCluster:   logicalcluster.Name("clusterName"),
 			expectedNamespace: "namespace",
 			expectedName:      "name",
 		},
 		{
 			name:            "cluster-scoped resource",
 			key:             "clusterName|name",
-			expectedCluster: logicalcluster.New("clusterName"),
+			expectedCluster: logicalcluster.Name("clusterName"),
 			expectedName:    "name",
 		},
 		{
@@ -185,7 +186,7 @@ func TestSplitMetaClusterNamespaceKey(t *testing.T) {
 		{
 			name:            "valid cluster, invalid key",
 			key:             "root:something|//2",
-			expectedCluster: logicalcluster.New("root:something"),
+			expectedCluster: logicalcluster.Name("root:something"),
 			expectedErr:     errors.New(`unexpected key format: "root:something|//2"`),
 		},
 	}
@@ -196,7 +197,7 @@ func TestSplitMetaClusterNamespaceKey(t *testing.T) {
 				t.Errorf("%s: invalid error: %v", testCase.name, diff)
 				return
 			}
-			if diff := cmp.Diff(actualCluster, testCase.expectedCluster, cmp.AllowUnexported(logicalcluster.Name{})); diff != "" {
+			if diff := cmp.Diff(actualCluster, testCase.expectedCluster); diff != "" {
 				t.Errorf("%s: invalid cluster: %v", testCase.name, diff)
 			}
 			if diff := cmp.Diff(actualNamespace, testCase.expectedNamespace); diff != "" {

--- a/pkg/cache/listers_test.go
+++ b/pkg/cache/listers_test.go
@@ -19,8 +19,9 @@ package cache
 import (
 	"testing"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,7 +113,7 @@ func TestGenericLister(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			lister := l.ByCluster(logicalcluster.New(tt.cluster))
+			lister := l.ByCluster(logicalcluster.Name(tt.cluster))
 
 			if tt.name == "" {
 				list, err := lister.List(tt.selector)
@@ -151,7 +152,7 @@ func TestGenericNamespaceLister(t *testing.T) {
 
 	cluster := "c1"
 
-	l := NewGenericClusterLister(indexer, schema.GroupResource{}).ByCluster(logicalcluster.New(cluster))
+	l := NewGenericClusterLister(indexer, schema.GroupResource{}).ByCluster(logicalcluster.Name(cluster))
 
 	tests := map[string]struct {
 		namespace  string

--- a/pkg/client/cluster_config.go
+++ b/pkg/client/cluster_config.go
@@ -19,7 +19,7 @@ package client
 import (
 	"net/http"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/client-go/rest"
 )
@@ -40,7 +40,7 @@ func SetMultiClusterRoundTripper(cfg *rest.Config) *rest.Config {
 // cluster endpoint.
 //
 // Note: it is the caller responsibility to make a copy of the rest config
-func SetCluster(cfg *rest.Config, clusterName logicalcluster.Name) *rest.Config {
-	cfg.Host = cfg.Host + clusterName.Path()
+func SetCluster(cfg *rest.Config, clusterPath logicalcluster.Path) *rest.Config {
+	cfg.Host = cfg.Host + clusterPath.RequestPath()
 	return cfg
 }

--- a/pkg/client/constructor.go
+++ b/pkg/client/constructor.go
@@ -20,7 +20,8 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/client-go/rest"
 )
 
@@ -31,8 +32,8 @@ type Constructor[R any] struct {
 
 // Cache is a client factory that caches previous results.
 type Cache[R any] interface {
-	ClusterOrDie(name logicalcluster.Name) R
-	Cluster(name logicalcluster.Name) (R, error)
+	ClusterOrDie(clusterPath logicalcluster.Path) R
+	Cluster(clusterPath logicalcluster.Path) (R, error)
 }
 
 // NewCache creates a new client factory cache using the given constructor.
@@ -42,8 +43,8 @@ func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constru
 		client:      client,
 		constructor: constructor,
 
-		RWMutex:          &sync.RWMutex{},
-		clientsByCluster: map[logicalcluster.Name]R{},
+		RWMutex:              &sync.RWMutex{},
+		clientsByClusterPath: map[logicalcluster.Path]R{},
 	}
 }
 
@@ -53,13 +54,13 @@ type clientCache[R any] struct {
 	constructor *Constructor[R]
 
 	*sync.RWMutex
-	clientsByCluster map[logicalcluster.Name]R
+	clientsByClusterPath map[logicalcluster.Path]R
 }
 
 // ClusterOrDie returns a new client scoped to the given logical cluster, or panics if there
 // is any error.
-func (c *clientCache[R]) ClusterOrDie(name logicalcluster.Name) R {
-	client, err := c.Cluster(name)
+func (c *clientCache[R]) ClusterOrDie(clusterPath logicalcluster.Path) R {
+	client, err := c.Cluster(clusterPath)
 	if err != nil {
 		// we ensure that the config is valid in the constructor, and we assume that any changes
 		// we make to it during scoping will not make it invalid, in order to hide the error from
@@ -70,17 +71,17 @@ func (c *clientCache[R]) ClusterOrDie(name logicalcluster.Name) R {
 }
 
 // Cluster returns a new client scoped to the given logical cluster.
-func (c *clientCache[R]) Cluster(name logicalcluster.Name) (R, error) {
+func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 	var cachedClient R
 	var exists bool
 	c.RLock()
-	cachedClient, exists = c.clientsByCluster[name]
+	cachedClient, exists = c.clientsByClusterPath[clusterPath]
 	c.RUnlock()
 	if exists {
 		return cachedClient, nil
 	}
 
-	cfg := SetCluster(rest.CopyConfig(c.cfg), name)
+	cfg := SetCluster(rest.CopyConfig(c.cfg), clusterPath)
 	instance, err := c.constructor.NewForConfigAndClient(cfg, c.client)
 	if err != nil {
 		var result R
@@ -89,12 +90,12 @@ func (c *clientCache[R]) Cluster(name logicalcluster.Name) (R, error) {
 
 	c.Lock()
 	defer c.Unlock()
-	cachedClient, exists = c.clientsByCluster[name]
+	cachedClient, exists = c.clientsByClusterPath[clusterPath]
 	if exists {
 		return cachedClient, nil
 	}
 
-	c.clientsByCluster[name] = instance
+	c.clientsByClusterPath[clusterPath] = instance
 
 	return instance, nil
 }

--- a/pkg/client/round_tripper_test.go
+++ b/pkg/client/round_tripper_test.go
@@ -19,7 +19,7 @@ package client
 import (
 	"testing"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 func TestRoundTripper_generatePath(t *testing.T) {
@@ -77,7 +77,7 @@ func TestRoundTripper_generatePath(t *testing.T) {
 	}
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
-			result := generatePath(tt.originalPath, logicalcluster.New("root:org:ws"))
+			result := generatePath(tt.originalPath, logicalcluster.NewPath("root:org:ws"))
 			if result != tt.desired {
 				t.Errorf("got %v, want %v", result, tt.desired)
 			}

--- a/third_party/informers/scoped_shared_informer.go
+++ b/third_party/informers/scoped_shared_informer.go
@@ -19,16 +19,18 @@ package informers
 import (
 	"time"
 
-	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/client-go/tools/cache"
+
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 )
 
 // scopedSharedIndexInformer ensures that event handlers added to the underlying
 // informer are only called with objects matching the given logical cluster
 type scopedSharedIndexInformer struct {
 	*sharedIndexInformer
-	cluster logicalcluster.Name
+	clusterName logicalcluster.Name
 }
 
 // AddEventHandler adds an event handler to the shared informer using the shared informer's resync
@@ -82,5 +84,5 @@ func (s *scopedSharedIndexInformer) objectMatches(obj interface{}) bool {
 	if err != nil {
 		return false
 	}
-	return cluster == s.cluster
+	return cluster == s.clusterName
 }

--- a/third_party/informers/scoped_shared_informer.go
+++ b/third_party/informers/scoped_shared_informer.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
-	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 )
 
 // scopedSharedIndexInformer ensures that event handlers added to the underlying

--- a/third_party/informers/shared_informer.go
+++ b/third_party/informers/shared_informer.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/utils/buffer"
 	"k8s.io/utils/clock"
 
-	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 )
 
 // NewSharedInformer creates a new instance for the listwatcher.

--- a/third_party/informers/shared_informer.go
+++ b/third_party/informers/shared_informer.go
@@ -23,17 +23,18 @@ import (
 	"sync"
 	"time"
 
-	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/buffer"
 	"k8s.io/utils/clock"
 
-	"k8s.io/klog/v2"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 )
 
 // NewSharedInformer creates a new instance for the listwatcher.
@@ -131,7 +132,7 @@ type sharedIndexInformer struct {
 func (s *sharedIndexInformer) Cluster(cluster logicalcluster.Name) cache.SharedIndexInformer {
 	return &scopedSharedIndexInformer{
 		sharedIndexInformer: s,
-		cluster:             cluster,
+		clusterName:         cluster,
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR switches the apimachinery repository to use `logicalcluster.v3` and also bumps the major version number for this repository to `v2` in the go.mod file. That means that users will have to import it as `github.com/kcp-dev/apimachinery/v2`

## Related issue(s)

Fixes #
