### PR TITLE
:seedling: remove unused ClusterRoundTripper

### DIFF
--- a/pkg/client/cluster_config.go
+++ b/pkg/client/cluster_config.go
@@ -17,24 +17,10 @@ limitations under the License.
 package client
 
 import (
-	"net/http"
-
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/client-go/rest"
 )
-
-// SetMultiClusterRoundTripper wraps an existing config's roundtripper
-// with a custom cluster aware roundtripper.
-//
-// Note: it is the caller responsibility to make a copy of the rest config
-func SetMultiClusterRoundTripper(cfg *rest.Config) *rest.Config {
-	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return NewClusterRoundTripper(rt)
-	})
-
-	return cfg
-}
 
 // SetCluster modifies the config host path to include the
 // cluster endpoint.

--- a/pkg/client/round_tripper.go
+++ b/pkg/client/round_tripper.go
@@ -18,34 +18,11 @@ package client
 
 import (
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 )
-
-// ClusterRoundTripper is a cluster aware wrapper around http.RoundTripper
-type ClusterRoundTripper struct {
-	delegate http.RoundTripper
-}
-
-// NewClusterRoundTripper creates a new cluster aware round tripper
-func NewClusterRoundTripper(delegate http.RoundTripper) *ClusterRoundTripper {
-	return &ClusterRoundTripper{
-		delegate: delegate,
-	}
-}
-
-func (c *ClusterRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	cluster, ok := logicalcluster.ClusterFromContext(req.Context())
-	if ok {
-		req = req.Clone(req.Context())
-		req.URL.Path = generatePath(req.URL.Path, cluster.Path())
-		req.URL.RawPath = generatePath(req.URL.RawPath, cluster.Path())
-	}
-	return c.delegate.RoundTrip(req)
-}
 
 // apiRegex matches any string that has /api/ or /apis/ in it.
 var apiRegex = regexp.MustCompile(`(/api/|/apis/)`)


### PR DESCRIPTION
Cleaning up deprecated roundtripper.

Follow-up: cleanup context funcs in logicalcluster repo.

Proof PR https://github.com/kcp-dev/kcp/pull/2552