### PR TITLE
:sparkles:  prow: use image ghcr.io/kcp-dev/infra/build:1.23.4-1

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.4-1
           command:
             - make
             - verify-boilerplate
@@ -20,7 +20,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.4-1
           command:
             - make
             - lint
@@ -33,7 +33,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.4-1
           command:
             - make
             - test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_INSTALL = ./hack/go-install.sh
 TOOLS_DIR=hack/tools
 GOBIN_DIR := $(abspath $(TOOLS_DIR))
 
-GOLANGCI_LINT_VER := v1.58.1
+GOLANGCI_LINT_VER := v1.62.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 


### PR DESCRIPTION
Continuing with https://github.com/kcp-dev/infra/issues/78, this PR uses the newer tag of the build image that contains go1.23 toolkit.