### PR TITLE
:bug: go.mod: removed explicit toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/kcp-dev/apimachinery/v2
 
 go 1.23.0
 
-toolchain go1.23.3
-
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/kcp-dev/logicalcluster/v3 v3.0.4


### PR DESCRIPTION
## Summary

This PR removes explicit go toolchain in go.mod. Golang version in the `go` directive is enough.

## Related issue(s)

Part of https://github.com/kcp-dev/kcp/issues/3209
