### PR TITLE
:seedling: Update OWNERS to reflect kcp maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,7 @@
 approvers:
-- ncdc
+- clubanderson
+- scheeles
 - sttts
-- stevekuznetsov
-- davidfestal
+- xrstf
+- mjudeikis
+- embik


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Looks like we forgot to update the `OWNERS` file in this repository, this aligns it with maintainers as of the last few years.

## Related issue(s)

Fixes #
